### PR TITLE
C++ fixes

### DIFF
--- a/templates/cpp/.codeclimate.yml
+++ b/templates/cpp/.codeclimate.yml
@@ -5,3 +5,6 @@ plugins:
     enabled: true
     config:
       filter: "-,+whitespace,+readability,-whitespace/ending_newline,-readability/multiline_string,-readability/casting"
+exclude_patterns:
+  - "build/"
+  - "test/"

--- a/templates/cpp/codefreak.yml
+++ b/templates/cpp/codefreak.yml
@@ -16,6 +16,7 @@ evaluation:
     results-path: test-results
     project-path: /code
     commands:
+    - "rm -rf build # Remove possible build files because there might be conflicting settings (i.e. the compiler path) from external builds"
     - cmake -s . -B build -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles"
     - make -C build ExampleProject_tst
     - build/test/ExampleProject_tst --gtest_output=xml:test-results/TEST-report.xml


### PR DESCRIPTION
Some fixes to bugs I encountered:
- When the CMake extension of VSCode is run, it creates a `build` directory. In this directory are (besides the build output) settings like the compiler path, which differs between the IDE image and the unit testing image. By removing it before running the unit tests, a new build directory is created with the correct settings.
- Code Climate evaluates the code quality of the generated build files as well as the test files, which is unnecessary, so those directories are excluded from the quality check now.